### PR TITLE
typo_fix + ipv6 disable support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,9 @@ postfix_smtpd_recipient_restrictions:
   - reject_rbl_client dul.dnsbl.sorbs.net
   - permit
 
+postfix_smtpd_sender_restrictions:
+  - reject_unknown_sender_domain
+
 # To enable spamassassin, ensure spamassassin is installed,
 # (hint: role: robertdebock.spamassassin) and set these two variables:
 # postfix_spamassassin: enabled

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ postfix_myorigin: "{{ ansible_domain | default ('localdomain', true) }}"
 # "all" or the name of the interface, such as "eth0".
 postfix_inet_interfaces: "loopback-only"
 
+# Enable IPv4, and IPv6 if supported - if IPV4 only set to ipv4
+postfix_inet_protocols: all
+
 # The distination tells Postfix what mails to accept mail for.
 postfix_mydestination: $mydomain, $myhostname, localhost.$mydomain, localhost
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ postfix_myorigin: "{{ ansible_domain | default ('localdomain', true) }}"
 
 # To "listen" on public interfaces, set inet_interfaces to something like
 # "all" or the name of the interface, such as "eth0".
-postfix_inet_inferfaces: "loopback-only"
+postfix_inet_interfaces: "loopback-only"
 
 # The distination tells Postfix what mails to accept mail for.
 postfix_mydestination: $mydomain, $myhostname, localhost.$mydomain, localhost

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -121,7 +121,7 @@ myorigin = {{ postfix_myorigin }}
 inet_interfaces = {{ postfix_inet_interfaces }}
 
 # Enable IPv4, and IPv6 if supported
-inet_protocols = all
+inet_protocols = {{ postfix_inet_protocols }}
 
 # The proxy_interfaces parameter specifies the network interface
 # addresses that this mail system receives mail on by way of a

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -698,7 +698,7 @@ sample_directory = /usr/share/doc/postfix-2.10.1/samples
 readme_directory = /usr/share/doc/postfix-2.10.1/README_FILES
 
 # content_filter: An optional filter to classify content.
-{% if postfix_clamav is defined %}
+{% if postfix_clamav is defined and postfix_clamav == "enabled" %}
 content_filter = scan:127.0.0.1:10025
 receive_override_options = no_address_mappings
 {% endif %}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -311,6 +311,10 @@ relay_domains = {{ postfix_relay_domains }}
 smtpd_recipient_restrictions = {% for smtpd_recipient_restriction in postfix_smtpd_recipient_restrictions %}{{ smtpd_recipient_restriction }}, {% endfor %}
 {% endif %}
 
+{% if postfix_smtpd_sender_restrictions is defined %}
+smtpd_sender_restrictions = {% for smtpd_sender_restriction in postfix_smtpd_sender_restrictions %}{{ smtpd_sender_restriction }}, {% endfor %}
+{% endif %}
+
 # INTERNET OR INTRANET
 
 # The relayhost parameter specifies the default host to send mail to

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -118,7 +118,7 @@ myorigin = {{ postfix_myorigin }}
 #inet_interfaces = $myhostname
 #inet_interfaces = $myhostname, localhost
 #inet_inferfaces = localhost
-inet_interfaces = {{ postfix_inet_inferfaces }}
+inet_interfaces = {{ postfix_inet_interfaces }}
 
 # Enable IPv4, and IPv6 if supported
 inet_protocols = all


### PR DESCRIPTION
This pull fixes a typo bug and add's support to disable ipv6