### PR TITLE
add tls_mandatory_protocols

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,6 @@ postfix_smtpd_sender_restrictions:
 #     action: OK
 #   - domain: baddomain.com
 #     action: REJECT
+
+# You can disable SSL/TLS versions here.
+# postfix_tls_protocols: '!SSLv2, !SSLv3, !TLSv1, !TLSv1.1'

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -724,4 +724,4 @@ smtpd_tls_mandatory_protocols = {{ postfix_tls_protocols }}
 smtpd_tls_protocols = {{ postfix_tls_protocols }}
 smtp_tls_mandatory_protocols = {{ postfix_tls_protocols }}
 smtp_tls_protocols = {{ postfix_tls_protocols }}
-{% end %}
+{% endif %}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -715,3 +715,13 @@ readme_directory = /usr/share/doc/postfix-2.10.1/README_FILES
 content_filter = scan:127.0.0.1:10025
 receive_override_options = no_address_mappings
 {% endif %}
+
+{% if postfix_tls_protocols is defined and postfix_tls_protocols | length > 0 %}
+# smtpd_tls_mandatory_protcols: TLS protocols accepted by the Postfix SMTP
+# server with mandatory TLS encryption.
+#
+smtpd_tls_mandatory_protocols = {{ postfix_tls_protocols }}
+smtpd_tls_protocols = {{ postfix_tls_protocols }}
+smtp_tls_mandatory_protocols = {{ postfix_tls_protocols }}
+smtp_tls_protocols = {{ postfix_tls_protocols }}
+{% end %}


### PR DESCRIPTION
**Describe the change**
Add parameters to main.cf which allow enabling and disabling specific SSL/TLS versions
This enables a resolution for the POODLE SSL vulnerability, as described in https://access.redhat.com/solutions/120383

**Testing**
Hopefully the GitHub Actions will run when I create the PR...
