### PR TITLE
replace dots in molecule instance hostnames

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     docker == 4.*
     ansible-lint == 5.*
 allowlist_externals = /bin/bash
-commands = /bin/bash -c 'TOX_ENVNAME="$\{TOX_ENV_NAME/\./_\}" && molecule test'
+commands = /bin/bash -c 'export TOX_ENVNAME="$\{TOX_ENV_NAME/\./_\}" && molecule test'
 setenv =
     PY_COLORS=1
     ANSIBLE_FORCE_COLOR=1

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ deps =
     molecule[docker]
     docker == 4.*
     ansible-lint == 5.*
-commands = bash -c 'TOX_ENVNAME="$\{TOX_ENV_NAME/\./_\} && molecule test'
+allowlist_externals = /bin/bash
+commands = /bin/bash -c 'TOX_ENVNAME="$\{TOX_ENV_NAME/\./_\}" && molecule test'
 setenv =
     PY_COLORS=1
     ANSIBLE_FORCE_COLOR=1

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,8 @@ deps =
     molecule[docker]
     docker == 4.*
     ansible-lint == 5.*
-commands = molecule test
+commands = bash -c 'TOX_ENVNAME="$\{TOX_ENV_NAME/\./_\} && molecule test'
 setenv =
-    TOX_ENVNAME={envname}
     PY_COLORS=1
     ANSIBLE_FORCE_COLOR=1
     ANSIBLE_ROLES_PATH=../


### PR DESCRIPTION
**Describe the change**
Fixes #11 by wrapping the call to `molecule test` with bash to replace `.` with `_` in `TOX_ENVNAME`.

There doesn't seem to be any nice way to do a string replace withing Tox or Molecule.
I don't think this is a great solution, but it does seem work. I was only working on this out of interest, I'm not using this role on Debian anyways.

**Testing**
GitHub Actions run successfully for all environments, and Molecule instance hostnames dot not contain dots, e.g. `postfix-debian-latestpy39-ansible-2_9`
