### PR TITLE
Added transport_maps and header_checks as optional feature

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,3 +76,9 @@ postfix_smtpd_sender_restrictions:
 
 # You can disable SSL/TLS versions here.
 # postfix_tls_protocols: '!SSLv2, !SSLv3, !TLSv1, !TLSv1.1'
+
+# You can supply a transport_maps Jinja2 template here
+# postfix_transport_maps_template: /path/to/transport.j2
+
+# You can supply a header_checks Jinja2 template here
+# postfix_header_checks_template: /path/to/header_checks.j2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,9 @@
 - name: rebuild recipient_access database
   ansible.builtin.command: postmap "{{ postfix_recipient_access_path }}"
 
+- name: rebuild transport_maps database
+  ansible.builtin.command: postmap /etc/postfix/transport
+
 - name: reload postfix
   ansible.builtin.service:
     name: "{{ postfix_service }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,26 @@
     name: "{{ postfix_packages }}"
     state: present
 
+- name: configure postfix (transport_maps)
+  ansible.builtin.template:
+    src: "{{ postfix_transport_maps_template }}"
+    dest: /etc/postfix/transport
+    mode: "0644"
+  notify:
+    - rebuild transport_maps database
+  when:
+    - postfix_transport_maps_template is defined
+
+- name: configure postfix (header_checks)
+  ansible.builtin.template:
+    src: "{{ postfix_header_checks_template }}"
+    dest: /etc/postfix/header_checks
+    mode: "0644"
+  notify:
+    - reload postfix
+  when:
+    - postfix_header_checks_template is defined
+
 - name: configure postfix (main.cf)
   ansible.builtin.template:
     src: main.cf.j2

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -579,6 +579,10 @@ alias_database = hash:/etc/aliases
 #
 #header_checks = regexp:/etc/postfix/header_checks
 
+{% if postfix_header_checks_template is defined %}
+header_checks = regexp:/etc/postfix/header_checks
+{% endif %}
+
 # FAST ETRN SERVICE
 #
 # Postfix maintains per-destination logfiles with information about
@@ -724,4 +728,10 @@ smtpd_tls_mandatory_protocols = {{ postfix_tls_protocols }}
 smtpd_tls_protocols = {{ postfix_tls_protocols }}
 smtp_tls_mandatory_protocols = {{ postfix_tls_protocols }}
 smtp_tls_protocols = {{ postfix_tls_protocols }}
+{% endif %}
+
+# Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
+# transport_maps = hash:/etc/postfix/transport
+{% if postfix_transport_maps_template is defined %}
+transport_maps = hash:/etc/postfix/transport
 {% endif %}


### PR DESCRIPTION
**Describe the change**
Adds the ability to supply Jinja templates for transport_maps and header_checks. Useful for setting up 'e-mail gateways'/SMTP Redirectors.

Example of how I implemented the added transport_maps feature in a playbook:

`./defaults/main.yml`
```
[...SNIP...]
relay_domains: 
  - item: domain.tld
    smtp_destination_host: ip.of.destination.server
    smtp_destination_port: 25
postfix_mynetworks: "127.0.0.0/8 , {% for network in relay_domains %}{{ network.smtp_destination_host }}{% if not loop.last %}, {% endif %}{% endfor %}"
[...SNIP...]
postfix_transport_maps_template: transport.j2 
[...SNIP...]
```

`./templates/transport.j2`
```yml
{% for domain in relay_domains %}{{ domain.item }} smtp:[{{ domain.smtp_destination_host}}]:{{ domain.smtp_destination_port }}
 
{% endfor %}
```

**Testing**
Role has been tested as part of a playbook against Ubuntu 20.04 VPS.
