### PR TITLE
Add smtp_tls_security_level parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ postfix_smtpd_recipient_restrictions:
 postfix_smtpd_sender_restrictions:
   - reject_unknown_sender_domain
 
+# The default SMTP TLS security level for the Postfix SMTP client
+# Valid values are: dane, encrypt, fingerprint, may, none, secure, verify
+postfix_smtp_tls_security_level: none
+
 # To enable spamassassin, ensure spamassassin is installed,
 # (hint: role: robertdebock.spamassassin) and set these two variables:
 # postfix_spamassassin: enabled

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ postfix_smtpd_recipient_restrictions:
 postfix_smtpd_sender_restrictions:
   - reject_unknown_sender_domain
 
+# The default SMTP TLS security level for the Postfix SMTP client
+# Valid values are: dane, encrypt, fingerprint, may, none, secure, verify
+postfix_smtp_tls_security_level: none
+
 # To enable spamassassin, ensure spamassassin is installed,
 # (hint: role: robertdebock.spamassassin) and set these two variables:
 # postfix_spamassassin: enabled

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -63,3 +63,11 @@
     quiet: yes
   when:
     - postfix_tls_protocols is defined
+
+- name: test if postfix_smtp_tls_security_level is set correctly
+  ansible.builtin.assert:
+    that:
+      - postfix_smtp_tls_security_level is defined
+      - postfix_smtp_tls_security_level is string
+      - postfix_smtp_tls_security_level in [ "dane", "encrypt", "fingerprint", "may", "none", "secure", "verify" ]
+    quiet: yes

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -730,6 +730,9 @@ smtp_tls_mandatory_protocols = {{ postfix_tls_protocols }}
 smtp_tls_protocols = {{ postfix_tls_protocols }}
 {% endif %}
 
+# The default SMTP TLS security level for the Postfix SMTP client
+smtp_tls_security_level = {{ postfix_smtp_tls_security_level }}
+
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = hash:/etc/postfix/transport
 {% if postfix_transport_maps_template is defined %}


### PR DESCRIPTION
**Describe the change**
This PR adds support for the configuration of the smtp_tls_security_level parameter.
This setting is `none` by default, but quite a few distros patch it to be `may` by default. For instance [Fedora](https://src.fedoraproject.org/rpms/postfix/blob/main/f/postfix-3.5.0-config.patch).

_Note: `may` means use TLS if this is supported by the remote SMTP server, otherwise use plaintext (opportunistic TLS outbound)._

**Testing**
Tested on Fedora 33/34 with Gmail

**References**
- http://www.postfix.org/postconf.5.html#smtp_tls_security_level
- https://serverfault.com/questions/853355/postfix-gmail-encryption/853363
- https://src.fedoraproject.org/rpms/postfix/blob/main/f/postfix-3.5.0-config.patch