### PR TITLE
Fixes bug introduced in 6a11191c86cac521647ea59313321a8cbba0dc4f

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -744,7 +744,7 @@ smtp_tls_security_level = {{ postfix_smtp_tls_security_level }}
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = hash:/etc/postfix/transport
 {% if postfix_transport_maps_template is defined %}
-transport_maps = {{ postfix_transport_maps_template }}
+transport_maps = hash:/etc/postfix/transport
 {% endif %}
 
 {% if postfix_biff is defined %}


### PR DESCRIPTION
---
name: Fixes bug introduced in 6a11191c86cac521647ea59313321a8cbba0dc4f
about: Reverts the value of `transport_maps` back to `hash:/etc/postfix/transport`

---

**Describe the change**
Reverts the value of `transport_maps` back to `hash:/etc/postfix/transport`. Currently it places the name of the template file in main.cf because in 6a11191c86cac521647ea59313321a8cbba0dc4f this was replaced with `{{ postfix_transport_maps_template }}`. `postfix_transport_maps_template` is the var that is used for the template src, it's not the actual location where postfix can find the transport file, this is currently hardcoded to `/etc/postfix/transport`.

**Testing**
Ubuntu 20.04
