### PR TITLE
Use postalias instead of postmap to rebuild alias database

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 
 - name: Rebuild alias database
   ansible.builtin.command:
-    cmd: postmap "{{ postfix_alias_path }}"
+    cmd: postalias "{{ postfix_alias_path }}"
 
 - name: Rebuild sender_access database
   ansible.builtin.command:


### PR DESCRIPTION
---
name: Pull request
about: Use postalias instead of postmap to rebuild alias database

---

**Describe the change**
Use postalias instead of postmap to rebuild alias database. Solves #23 

**Testing**
For testing purposes, the role was  applied against a set of hosts with different OSes including ubuntu-22.04, debian-11, centos-9, rock-9, and fedora-37
