### PR TITLE
Set Postfix compatibility_level parameter in main.cf

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -11,6 +11,25 @@
 # For best results, change no more than 2-3 parameters at a time,
 # and test if Postfix still works after every change.
 
+# COMPATIBILITY
+#
+# The compatibility_level determines what default settings Postfix
+# will use for main.cf and master.cf settings. These defaults will
+# change over time.
+#
+# To avoid breaking things, Postfix will use backwards-compatible
+# default settings and log where it uses those old backwards-compatible
+# default settings, until the system administrator has determined
+# if any backwards-compatible default settings need to be made
+# permanent in main.cf or master.cf.
+#
+# When this review is complete, update the compatibility_level setting
+# below as recommended in the RELEASE_NOTES file.
+#
+# The level below is what should be used with new (not upgrade) installs.
+#
+compatibility_level = {{ postfix_compatibility_level }}
+
 # SOFT BOUNCE
 #
 # The soft_bounce parameter provides a limited safety net for

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -25,3 +25,9 @@ _postfix_group:
   Suse: maildrop
 
 postfix_group: "{{ _postfix_group[ansible_os_family] | default(_postfix_group['default']) }}"
+
+_postfix_compatibility_level:
+  default: 2
+  jammy: 3.6
+
+postfix_compatibility_level: "{{ _postfix_compatibility_level[ansible_distribution_release] | default(_postfix_compatibility_level['default']) }}"


### PR DESCRIPTION
---
name: Pull request
about: Set Postfix compatibility_level parameter in main.cf

---

**Describe the change**
Set Postfix compatibility_level parameter in main.cf. Solves #25 

**Testing**
For testing purposes, the role was applied against a set of hosts with different OSes including ubuntu-22.04, debian-11, centos-9, rock-9, and fedora-37.
