### PR TITLE
Fix handling of parameters as list vs. comma-separated strings

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -40,14 +40,14 @@
   ansible.builtin.assert:
     that:
       - postfix_mydestination is defined
-      - postfix_mydestination is string
+      - postfix_mydestination is iterable or postfix_mydestination is string
     quiet: yes
 
 - name: Test if postfix_mynetworks is set correctly
   ansible.builtin.assert:
     that:
       - postfix_mynetworks is defined
-      - postfix_mynetworks is iterable
+      - postfix_mynetworks is iterable or postfix_mynetworks is string
     quiet: yes
 
 - name: Test if postfix_smtpd_recipient_restrictions is set correctly

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,81 @@
   when:
     - postfix_header_checks_template is defined
 
+- name: "Setting values for main.cf (1/2)"
+  ansible.builtin.set_fact:
+    _postfix_smtpd_recipient_restrictions_check_recipient_access: |
+      {% if postfix_recipient_access is defined %}
+      check_recipient_access hash:{{ postfix_recipient_access_path }},
+      {% endif %}
+    _postfix_smtpd_sender_restrictions_check_sender_access: |
+      {% if postfix_sender_access is defined %}
+      check_sender_access hash:{{ postfix_sender_access_path }},
+      {% endif %}
+
+- name: "Setting values for main.cf (2/2)"
+  ansible.builtin.set_fact:
+    _postfix_mynetworks: >-
+      {% if postfix_mynetworks is string %}{{ postfix_mynetworks }}
+      {% elif postfix_mynetworks is iterable and (postfix_mynetworks is not string and postfix_mynetworks is not mapping) %}
+      {% for network in postfix_mynetworks %}{{ network }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+    _postfix_mydestination: >-
+      {% if postfix_mydestination is defined %}
+      {% if postfix_mydestination is string %}
+      {{ postfix_mydestination }}
+      {% elif postfix_mydestination is iterable and (postfix_mydestination is not string and postfix_mydestination is not mapping) %}
+      {% for domain in postfix_mydestination %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% else %}
+      <None>
+      {% endif %}
+    _postfix_relay_domains: >-
+      {% if postfix_relay_domains is defined %}
+      {% if postfix_relay_domains is string %}
+      {{ postfix_relay_domains }}
+      {% elif postfix_relay_domains is iterable and (postfix_relay_domains is not string and postfix_relay_domains is not mapping) %}
+      {% for domain in postfix_relay_domains %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% else %}
+      <None>
+      {% endif %}
+    _postfix_smtpd_recipient_restrictions: >-
+      {% if postfix_smtpd_recipient_restrictions is defined %}
+      {% if postfix_smtpd_recipient_restrictions is string %}
+      {{ _postfix_smtpd_recipient_restrictions_check_recipient_access | trim }} {{ postfix_smtpd_recipient_restrictions }}
+      {% elif postfix_smtpd_recipient_restrictions is iterable and (postfix_smtpd_recipient_restrictions is not string and postfix_smtpd_recipient_restrictions is not mapping) %}
+      {{ _postfix_smtpd_recipient_restrictions_check_recipient_access | trim }} {% for domain in postfix_smtpd_recipient_restrictions %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% endif %}
+    _postfix_smtpd_sender_restrictions: >-
+      {% if postfix_smtpd_sender_restrictions is defined %}
+      {% if postfix_smtpd_sender_restrictions is string %}
+      {{ _postfix_smtpd_sender_restrictions_check_sender_access | trim }} {{ postfix_smtpd_sender_restrictions }}
+      {% elif postfix_smtpd_sender_restrictions is iterable and (postfix_smtpd_sender_restrictions is not string and postfix_smtpd_sender_restrictions is not mapping) %}
+      {{ _postfix_smtpd_sender_restrictions_check_sender_access | trim }} {% for domain in postfix_smtpd_sender_restrictions %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% endif %}
+    _postfix_virtual_mailbox_domains: >-
+      {% if postfix_virtual_mailbox_domains is defined %}
+      {% if postfix_virtual_mailbox_domains is string %}
+      {{ postfix_virtual_mailbox_domains }}
+      {% elif postfix_virtual_mailbox_domains is iterable and (postfix_virtual_mailbox_domains is not string and postfix_virtual_mailbox_domains is not mapping) %}
+      {% for domain in postfix_virtual_mailbox_domains %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% else %}
+      <None>
+      {% endif %}
+    _postfix_virtual_alias_domains: >-
+      {% if postfix_virtual_alias_domains is defined %}
+      {% if postfix_virtual_alias_domains is string %}
+      {{ postfix_virtual_alias_domains }}
+      {% elif postfix_virtual_alias_domains is iterable and (postfix_virtual_alias_domains is not string and postfix_virtual_alias_domains is not mapping) %}
+      {% for domain in postfix_virtual_alias_domains %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% else %}
+      <None>
+      {% endif %}
+
 - name: Configure postfix (main.cf)
   ansible.builtin.template:
     src: main.cf.j2

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -170,8 +170,8 @@ inet_protocols = {{ postfix_inet_protocols }}
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain,
 #	mail.$mydomain, www.$mydomain, ftp.$mydomain
-{% if postfix_mydestination is defined %}
-mydestination = {{ postfix_mydestination }}
+{% if _postfix_mydestination != "<None>" %}
+mydestination = {{ _postfix_mydestination | trim }}
 {% endif %}
 
 # REJECTING MAIL FOR UNKNOWN LOCAL USERS
@@ -272,7 +272,7 @@ unknown_local_recipient_reject_code = 550
 #mynetworks = 168.100.189.0/28, 127.0.0.0/8
 #mynetworks = $config_directory/mynetworks
 #mynetworks = hash:/etc/postfix/network_table
-mynetworks = {% for network in postfix_mynetworks %}{{ network }}{% if not loop.last %}, {% endif %}{% endfor %}
+mynetworks = {{ _postfix_mynetworks | trim }}
 
 # The relay_domains parameter restricts what destinations this system will
 # relay mail to.  See the smtpd_recipient_restrictions description in
@@ -303,25 +303,13 @@ mynetworks = {% for network in postfix_mynetworks %}{{ network }}{% if not loop.
 # permit_mx_backup restriction description in postconf(5).
 #
 #relay_domains = $mydestination
-{% if postfix_relay_domains is defined %}
-relay_domains = {{ postfix_relay_domains }}
+{% if _postfix_relay_domains != "<None>" %}
+relay_domains = {{ _postfix_relay_domains | trim }}
 {% endif %}
 
-{% if postfix_smtpd_recipient_restrictions is defined and postfix_recipient_access is not defined %}
-smtpd_recipient_restrictions = {% for smtpd_recipient_restriction in postfix_smtpd_recipient_restrictions %}{{ smtpd_recipient_restriction }}, {% endfor %}
-{% endif %}
+smtpd_recipient_restrictions = {{ _postfix_smtpd_recipient_restrictions | trim }}
 
-{% if postfix_smtpd_recipient_restrictions is defined and postfix_recipient_access is defined %}
-smtpd_recipient_restrictions = check_recipient_access hash:{{ postfix_recipient_access_path }}, {% for smtpd_recipient_restriction in postfix_smtpd_recipient_restrictions %}{{ smtpd_recipient_restriction }}, {% endfor %}
-{% endif %}
-
-{% if postfix_smtpd_sender_restrictions is defined and postfix_sender_access is not defined %}
-smtpd_sender_restrictions = {% for smtpd_sender_restriction in postfix_smtpd_sender_restrictions %}{{ smtpd_sender_restriction }}, {% endfor %}
-{% endif %}
-
-{% if postfix_smtpd_sender_restrictions is defined and postfix_sender_access is defined %}
-smtpd_sender_restrictions = check_sender_access hash:{{ postfix_sender_access_path }}, {% for smtpd_sender_restriction in postfix_smtpd_sender_restrictions %}{{ smtpd_sender_restriction }}, {% endfor %}
-{% endif %}
+smtpd_sender_restrictions = {{ _postfix_smtpd_sender_restrictions | trim }}
 
 
 # INTERNET OR INTRANET
@@ -763,12 +751,12 @@ virtual_mailbox_base = {{ postfix_virtual_mailbox_base }}
 virtual_mailbox_maps = {{ postfix_virtual_mailbox_maps }}
 {% endif %}
 
-{% if postfix_virtual_mailbox_domains is defined %}
-virtual_mailbox_domains = {{ postfix_virtual_mailbox_domains }}
+{% if _postfix_virtual_mailbox_domains | trim != "<None>" %}
+virtual_alias_domains = {{ _postfix_virtual_mailbox_domains | trim }}
 {% endif %}
 
-{% if postfix_virtual_alias_domains is defined %}
-virtual_alias_domains = {{ postfix_virtual_alias_domains }}
+{% if _postfix_virtual_alias_domains | trim != "<None>" %}
+virtual_mailbox_domains = {{ _postfix_virtual_alias_domains | trim }}
 {% endif %}
 
 {% if postix_virtual_alias_maps is defined %}


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
The handling of postfix settings which may contain lists is currently not handled consistently in this role

Some settings expect yaml lists, e.g.:
- postfix_mynetworks
- postfix_smtpd_recipient_restrictions
- postfix_smtpd_sender_restrictions

Some others expect yaml strings with comma-separated values, e.g.:
- postfix_mydestination
- postfix_relay_domains
- postfix_virtual_mailbox_domains
- postfix_virtual_alias_domains

This PR allows all of these settings to be set as yaml string or as yaml list. The user of the role can chose whatever appears more suitable.

**Testing**
Ubuntu 22.04