### PR TITLE
#28 postfix address rewrite

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,11 @@ postfix_smtp_tls_security_level: none
 #   - name: root
 #     destination: robert@meinit.nl
 
+# You can configure smtp_generics for address rewriting here.
+# postfix_smtp_generic:
+#   - envelope_or_header_address: @localdomain.local
+#     sender_address: robert@meinit.nl
+
 # You can configure sender access controls here.
 # postfix_sender_access:
 #   - domain: gooddomain.com

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,11 @@
     cmd: postalias "{{ postfix_alias_path }}"
   changed_when: yes
 
+- name: Rebuild smtp_generic database
+  ansible.builtin.command:
+    cmd: postmap "{{ postfix_smtp_generic_path }}"
+  changed_when: yes
+
 - name: Rebuild sender_access database
   ansible.builtin.command:
     cmd: postmap "{{ postfix_sender_access_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -168,7 +168,7 @@
 - name: Configure smtp_generics
   ansible.builtin.lineinfile:
     path: "{{ postfix_smtp_generic_path }}"
-    regexp: "^{{ item.envelope_or_header_address }}\s"
+    regexp: "^{{ item.envelope_or_header_address }}\\s+"
     line: "{{ item.envelope_or_header_address }} {{ item.sender_address }}"
     mode: "0644"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,6 +165,21 @@
   loop_control:
     label: "{{ item.name }}"
 
+- name: Configure smtp_generics
+  ansible.builtin.lineinfile:
+    path: "{{ postfix_smtp_generic_path }}"
+    regexp: "^{{ item.envelope_or_header_address }}\s"
+    line: "{{ item.envelope_or_header_address }} {{ item.sender_address }}"
+    mode: "0644"
+  when:
+    - postfix_smtp_generic is defined
+  loop: "{{ postfix_smtp_generic }}"
+  notify:
+    - Rebuild smtp_generic database
+    - Reload postfix
+  loop_control:
+    label: "{{ item.envelope_or_header_address }}"
+
 - name: Configure sender_access
   ansible.builtin.lineinfile:
     path: "{{ postfix_sender_access_path }}"

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -439,6 +439,10 @@ alias_maps = {{ postfix_alias_maps }}
 alias_database = hash:/etc/aliases
 #alias_database = hash:/etc/aliases, hash:/opt/majordomo/aliases
 
+{% if postfix_smtp_generic is defined %}
+smtp_generic_maps = hash:{{ postfix_smtp_generic_path }}
+{% endif %}
+
 # ADDRESS EXTENSIONS (e.g., user+foo)
 #
 # The recipient_delimiter parameter specifies the separator between

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,6 +16,11 @@ _postfix_alias_path:
 
 postfix_alias_path: "{{ _postfix_alias_path[ansible_os_family] | default(_postfix_alias_path['default']) }}"
 
+_postfix_smtp_generic_path:
+  default: /etc/postfix/generic
+
+postfix_smtp_generic_path: "{{ _postfix_smtp_generic_path[ansible_os_family] | default(_postfix_smtp_generic_path['default']) }}"
+
 postfix_recipient_access_path: /etc/postfix/recipient_access
 
 postfix_sender_access_path: /etc/postfix/sender_access


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
Adds the feature postfix address rewrite.

**Testing**
Was deployed via ansible to own infrastructure and replaced the manual additions as expected.

```shell
cat >postfix.yml<<"EOF" && ansible-playbook -i hosts.postfix postfix.yml -l cmk03.example.com --check --diff
- name: Configure postfix
  hosts: all
  become: yes
  gather_facts: yes

  roles:
    - role: ansible-role-postfix # replace with robertdebock.roles.postfix when feature is merged
      postfix_relayhost: "[relay.example.com]:25"
      postfix_myhostname: "{{ inventory_hostname }}"
      postfix_mydomain: "{{ ansible_domain }}"
      postfix_myorigin: "{{ ansible_domain }}"
      postfix_mynetworks:
        - 127.0.0.0/8
      postfix_aliases:
        - name: root
          destination: robert@example.com
      postfix_smtp_generic:
        - envelope_or_header_address: "@{{ inventory_hostname }}"
          sender_address: monitoring@example.com
        - envelope_or_header_address: "@{{ ansible_domain }}"
          sender_address: monitoring@example.com
EOF
```

```diff
--- before: /etc/postfix/main.cf
+++ after: ~/ansible/tmp/ansible-local-401679690qn44du/tmpn458ld6a/main.cf.j2
+
+smtp_generic_maps = hash:/etc/postfix/generic

 # ADDRESS EXTENSIONS (e.g., user+foo)
 #                                                                                                                                                                                                                                                                                      @@ -722,4 +724,37 @@
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).                                                                                                                                                                    # transport_maps = hash:/etc/postfix/transport

-smtp_generic_maps = hash:/etc/postfix/generic
```

Additionally the new task would have added the bevor manually added entries into smtp_generic_map file.

```txt
TASK [ansible-role-postfix : Configure smtp_generics]
********************************************************************
ok: [cmk03.example.com] => (item=@cmk03.example.com)
ok: [cmk03.example.com] => (item=@example.com)
```

