### PR TITLE
 Fixes and improvements for authentication on outgoing relay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
           destination: test@example.com
       # Ziggo settings: ("email-address" and "email-password" are placeholders)
       postfix_relayhost: "[smtp.ziggo.nl]:587"
-      postfix_smtp_use_tls: true
       postfix_smtp_sasl_auth_enable: true
       postfix_smtp_sasl_password_map: "/etc/postfix/relay_pass"
       postfix_smtp_sasl_security_options: ""
@@ -280,11 +279,11 @@ postfix_smtp_tls_security_level: none
 # So either specifcy a port number or a service name like `smtp`.
 postfix_smtp_listen_port: smtp
 
-postfix_smtp_use_tls: false
 postfix_smtp_sasl_auth_enable: false
 postfix_smtp_sasl_password_map: ""
 postfix_smtp_sasl_security_options: ""
 postfix_smtp_tls_wrappermode: false
+postfix_smtp_tls_security_level: may
 postfix_smtp_sasl_password_map_content: ""
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -216,7 +216,6 @@ postfix_smtp_tls_security_level: none
 # So either specifcy a port number or a service name like `smtp`.
 postfix_smtp_listen_port: smtp
 
-postfix_smtp_use_tls: false
 postfix_smtp_sasl_auth_enable: false
 postfix_smtp_sasl_password_map: ""
 postfix_smtp_sasl_security_options: ""

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -18,7 +18,6 @@
           destination: test@example.com
       # Ziggo settings: ("email-address" and "email-password" are placeholders)
       postfix_relayhost: "[smtp.ziggo.nl]:587"
-      postfix_smtp_use_tls: true
       postfix_smtp_sasl_auth_enable: true
       postfix_smtp_sasl_password_map: "/etc/postfix/relay_pass"
       postfix_smtp_sasl_security_options: ""

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -426,14 +426,6 @@
         postfix_smtp_listen_port is string
     quiet: true
 
-- name: assert | Test postfix_smtp_use_tls
-  ansible.builtin.assert:
-    that:
-      - postfix_smtp_use_tls is boolean
-    quiet: true
-  when:
-    - postfix_smtp_use_tls is defined
-
 - name: assert | Test postfix_smtp_sasl_auth_enable
   ansible.builtin.assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -204,7 +204,7 @@
     dest: "{{ postfix_smtp_sasl_password_map }}"
     mode: "0600"
   when:
-    - postfix_smtp_sasl_password_map is defined
+    - postfix_smtp_sasl_password_map is defined and postfix_smtp_sasl_password_map != ""
   notify:
     - Rebuild sasl_password_map database
 

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -896,8 +896,11 @@ bounce_queue_lifetime = {{ postfix_bounce_queue_lifetime }}
 {% endif %}
 
 # https://stafwag.github.io/blog/blog/2018/03/04/postfix-smarthost-with-authentication/
-smtp_use_tls = {{ postfix_smtp_use_tls | ternary('yes', 'no') }}
 smtp_sasl_auth_enable = {{ postfix_smtp_sasl_auth_enable | ternary('yes', 'no') }}
+{% if postfix_smtp_sasl_password_map is defined and postfix_smtp_sasl_password_map != "" %}
 smtp_sasl_password_maps = hash:{{ postfix_smtp_sasl_password_map }}
+{% endif %}
+{% if postfix_smtp_sasl_security_options is defined and postfix_smtp_sasl_security_options != "" %}
 smtp_sasl_security_options = {{ postfix_smtp_sasl_security_options }}
+{% endif %}
 smtp_tls_wrappermode = {{ postfix_smtp_tls_wrappermode | ternary('yes', 'no') }}


### PR DESCRIPTION
---
name: Pull request
about:  Fixes and improvements for authentication on outgoing relay.

---

**Describe the change**
1. Fixes a bug which caused an error when `postfix_smtp_sasl_password_map` was left on the default value (empty string).

2. Removes the obsolete `smtp_use_tls` setting.
With Postfix 2.3+, `smtp_tls_security_level` should be used instead (https://www.postfix.org/postconf.5.html#smtp_use_tls), which overrides `smtp_use_tls` (https://www.postfix.org/postconf.5.html#smtp_tls_security_level).

3. Only insert `postfix_smtp_sasl_password_map` and `postfix_smtp_sasl_security_options` into `main.cf`
 if it contains a non-empty string.

**Testing**
For testing purposes, the role was applied against  hosts with ubuntu-24-04 and  ubuntu-22.04.