### PR TITLE
Allow deployment of TLS certificate and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,14 @@ postfix_smtp_tls_security_level: none
 # File with the Postfix SMTP server RSA certificate in PEM format.
 # postfix_smtpd_tls_cert_file: /etc/letsencrypt/live/smtp.syhosting.ch/cert.pem
 
+# Local file with the Postfix SMTP server RSA certificate in PEM format which shall be copied to the target host.
+# postfix_smtpd_tls_cert_file_source: ./certs/cert.pem
+
 # File with the Postfix SMTP server RSA private key in PEM format.
 # postfix_smtpd_tls_key_file: /etc/letsencrypt/live/smtp.syhosting.ch/privkey.pem
+
+# Local file with the Postfix SMTP server RSA private key in PEM format which shall be copied to the target host.
+# postfix_smtpd_tls_key_file_source: ./certs/privkey.pem
 
 # Request that the Postfix SMTP server produces Received: message headers that include information about the protocol and cipher used, as well as the remote SMTP client CommonName and client certificate issuer CommonName.
 # postfix_smtpd_tls_received_header: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,8 +142,14 @@ postfix_smtp_tls_security_level: none
 # File with the Postfix SMTP server RSA certificate in PEM format.
 # postfix_smtpd_tls_cert_file: /etc/letsencrypt/live/smtp.syhosting.ch/cert.pem
 
+# Local file with the Postfix SMTP server RSA certificate in PEM format which shall be copied to the target host.
+# postfix_smtpd_tls_cert_file_source: ./certs/cert.pem
+
 # File with the Postfix SMTP server RSA private key in PEM format.
 # postfix_smtpd_tls_key_file: /etc/letsencrypt/live/smtp.syhosting.ch/privkey.pem
+
+# Local file with the Postfix SMTP server RSA private key in PEM format which shall be copied to the target host.
+# postfix_smtpd_tls_key_file_source: ./certs/privkey.pem
 
 # Request that the Postfix SMTP server produces Received: message headers that include information about the protocol and cipher used, as well as the remote SMTP client CommonName and client certificate issuer CommonName.
 # postfix_smtpd_tls_received_header: true

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -236,6 +236,17 @@
   when:
     - postfix_smtpd_tls_key_file is defined
 
+- name: assert | Test either postfix_smtpd_tls_cert_file_source and postfix_smtpd_tls_key_file_source are defined both or none
+  ansible.builtin.assert:
+    that:
+      - postfix_smtpd_tls_cert_file_source is string
+      - postfix_smtpd_tls_cert_file_source is not none
+      - postfix_smtpd_tls_key_file_source is string
+      - postfix_smtpd_tls_key_file_source is not none
+    quiet: true
+  when:
+    - postfix_smtpd_tls_cert_file_source is defined or postfix_smtpd_tls_key_file_source is defined
+
 - name: assert | Test postfix_smtpd_tls_received_header
   ansible.builtin.assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,6 +147,40 @@
     - Validate configuration
     - Restart postfix
 
+- name: Creates cert/key directory
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0700
+  loop:
+    - "{{ postfix_smtpd_tls_cert_file | dirname }}"
+    - "{{ postfix_smtpd_tls_key_file | dirname }}"
+  when:
+    - postfix_smtpd_tls_cert_file is defined
+    - postfix_smtpd_tls_key_file is defined
+    - postfix_smtpd_tls_cert_file_source is defined
+    - postfix_smtpd_tls_key_file_source is defined
+
+- name: Deploy Postfix TLS server certificate
+  ansible.builtin.copy:
+    src: "{{ postfix_smtpd_tls_cert_file_source }}"
+    dest: "{{ postfix_smtpd_tls_cert_file }}"
+    mode: "0600"
+  notify:
+    - Reload postfix
+  when:
+    - postfix_smtpd_tls_cert_file_source is defined
+
+- name: Deploy Postfix TLS server key
+  ansible.builtin.copy:
+    src: "{{ postfix_smtpd_tls_key_file_source }}"
+    dest: "{{ postfix_smtpd_tls_key_file }}"
+    mode: "0600"
+  notify:
+    - Reload postfix
+  when:
+    - postfix_smtpd_tls_key_file_source is defined
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
---
name: Pull request
about: Allow deployment of TLS certificate and key

---

**Describe the change**
Defines two new variables postfix_smtpd_tls_cert_file_source and postfix_smtpd_tls_key_file_source which contain paths to the local source of tls certificate and key. This can be used to deploy certificate and key to the managed server.

**Testing**
For testing purposes, the role was applied against hosts with ubuntu-24-04 and ubuntu-22.04.
