### PR TITLE
add ability to add custom master.cf entries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,6 +217,9 @@ postfix_smtp_tls_security_level: none
 # The location of Postfix HTML files that describe how to build, configure or operate a specific Postfix subsystem or feature.
 # postfix_html_directory: /usr/share/doc/postfix/html
 
+# List of custom master.cf entries if more services are needed outside of postfix defaults
+# postfix_master_custom: []
+
 # You can change the port where Postfix listens on.
 # Postfix used `/etc/services` to map service names to port numbers like `2525`.
 # So either specifcy a port number or a service name like `smtp`.

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -480,3 +480,11 @@
     quiet: true
   when:
     - postfix_smtp_sasl_password_map_content is defined
+
+- name: assert | Test postfix_master_custom
+  ansible.builtin.assert:
+    that:
+      - postfix_master_custom is iterable
+    quiet: true
+  when:
+    - postfix_master_custom is defined

--- a/templates/master.cf.j2
+++ b/templates/master.cf.j2
@@ -29,6 +29,11 @@ scan      unix  -       -       n       -       16      smtp
   -o mynetworks_style=host
   -o smtpd_authorized_xforward_hosts=127.0.0.0/8
 {% endif %}
+{% if postfix_master_custom is defined %}
+{% for item in postfix_master_custom %}
+{{ item }}
+{% endfor %}
+{% endif %}
 #smtp      inet  n       -       n       -       1       postscreen
 #smtpd     pass  -       -       n       -       -       smtpd
 #dnsblog   unix  -       -       n       -       0       dnsblog


### PR DESCRIPTION
---
name: Add the ability to append custom master.cf entries
about: In our current postfix setup, we have some custom entries defined in our master.cf for custom services to allow trusted systems to have more relaxed controls.  

---

**Describe the change**
Currently, this role does not support those custom entries, so this pull request adds that functionality.  The variable "postfix_master_custom" can be used to add a single or multiple master entries.

**Testing**
Added check in assert to validate "postfix_master_custom" is iterable, if defined
