### PR TITLE
virtual_alias and virtual_mailbox confusion / custom transport_maps

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -750,7 +750,9 @@ smtp_tls_security_level = {{ postfix_smtp_tls_security_level }}
 
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = hash:/etc/postfix/transport
-{% if postfix_transport_maps_template is defined %}
+{% if postfix_transport_maps_custom is defined %}
+transport_maps = {{ postfix_transport_maps_custom }}
+{% elif postfix_transport_maps_template is defined %}
 transport_maps = hash:/etc/postfix/transport
 {% endif %}
 
@@ -771,11 +773,11 @@ virtual_mailbox_maps = {{ postfix_virtual_mailbox_maps }}
 {% endif %}
 
 {% if _postfix_virtual_mailbox_domains | trim != "<None>" %}
-virtual_alias_domains = {{ _postfix_virtual_mailbox_domains | trim }}
+virtual_mailbox_domains = {{ _postfix_virtual_mailbox_domains | trim }}
 {% endif %}
 
 {% if _postfix_virtual_alias_domains | trim != "<None>" %}
-virtual_mailbox_domains = {{ _postfix_virtual_alias_domains | trim }}
+virtual_alias_domains = {{ _postfix_virtual_alias_domains | trim }}
 {% endif %}
 
 {% if postix_virtual_alias_maps is defined %}


### PR DESCRIPTION
Hello! Thanks for this customizable postfix role, it's the best candidate I found for my purpose: configuring postfix as [the MTA of Sympa mailing list](https://www.sympa.community/manual/install/configure-mail-server-postfix.html).

It almost works: I found a switch between `virtual_mailbox_domains` and `virtual_alias_domains`. I think it's just a confusion.

And the `transport_maps` definition of the role, with a single hash data template, did not fit the requirements. I propose you a `postfix_transport_maps_custom` flag parameter that allows to overwrite the definition.