### PR TITLE
More options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ postfix_smtpd_recipient_restrictions:
 postfix_smtpd_sender_restrictions:
   - reject_unknown_sender_domain
 
+# Set the restrictions for client access.
+#postfix_smtpd_client_restrictions:
+#  - permit_mynetworks
+#  - reject_unknown_client
+#  - permit
+
+# Set the restrictions for relaying.
+#postfix_smtpd_relay_restrictions:
+#  - permit_mynetworks
+#  - permit_sasl_authenticated
+#  - defer_unauth_destination
+
 # The default SMTP TLS security level for the Postfix SMTP client
 # Valid values are: dane, encrypt, fingerprint, may, none, secure, verify
 postfix_smtp_tls_security_level: none
@@ -143,6 +155,20 @@ postfix_smtp_tls_security_level: none
 #   - domain: gooddomain.com
 #     action: OK
 #   - domain: baddomain.com
+#     action: REJECT
+
+# You can configure client access controls here.
+# postfix_client_access:
+#   - client: 192.168.1.10
+#     action: OK
+#   - client: 192.168.1.20
+#     action: REJECT
+
+# You can configure relay access controls here.
+# postfix_relay_access:
+#   - client: 192.168.1.10
+#     action: OK
+#   - client: 192.168.1.20
 #     action: REJECT
 
 # You can disable SSL/TLS versions here.
@@ -293,6 +319,23 @@ postfix_smtp_sasl_password_map: ""
 postfix_smtp_sasl_security_options: ""
 postfix_smtp_tls_wrappermode: false
 postfix_smtp_sasl_password_map_content: ""
+postfix_smtp_use_tls: "no"
+postfix_smtp_tls_note_starttls_offer: "no"
+postfix_smtp_tls_CAfile: ""
+postfix_smtp_tls_CApath: ""
+postfix_tls_append_default_CA: "no"
+
+postfix_smtp_sender_dependent_authentication: "no"
+postfix_sender_dependent_relayhost_map: ""
+postfix_sender_dependent_relayhost_map_content: []
+
+postfix_sender_canonical_classes: "envelope_sender, header_sender"
+postfix_sender_canonical_map: ""
+postfix_sender_canonical_map_content: []
+
+# Debugging options
+postfix_debug_peer_level: 2
+# postfix_debug_peer_list: []
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,18 @@ postfix_smtpd_recipient_restrictions:
 postfix_smtpd_sender_restrictions:
   - reject_unknown_sender_domain
 
+# Set the restrictions for client access.
+#postfix_smtpd_client_restrictions:
+#  - permit_mynetworks
+#  - reject_unknown_client
+#  - permit
+
+# Set the restrictions for relaying.
+#postfix_smtpd_relay_restrictions:
+#  - permit_mynetworks
+#  - permit_sasl_authenticated
+#  - defer_unauth_destination
+
 # The default SMTP TLS security level for the Postfix SMTP client
 # Valid values are: dane, encrypt, fingerprint, may, none, secure, verify
 postfix_smtp_tls_security_level: none
@@ -80,6 +92,20 @@ postfix_smtp_tls_security_level: none
 #   - domain: gooddomain.com
 #     action: OK
 #   - domain: baddomain.com
+#     action: REJECT
+
+# You can configure client access controls here.
+# postfix_client_access:
+#   - client: 192.168.1.10
+#     action: OK
+#   - client: 192.168.1.20
+#     action: REJECT
+
+# You can configure relay access controls here.
+# postfix_relay_access:
+#   - client: 192.168.1.10
+#     action: OK
+#   - client: 192.168.1.20
 #     action: REJECT
 
 # You can disable SSL/TLS versions here.
@@ -230,3 +256,20 @@ postfix_smtp_sasl_password_map: ""
 postfix_smtp_sasl_security_options: ""
 postfix_smtp_tls_wrappermode: false
 postfix_smtp_sasl_password_map_content: ""
+postfix_smtp_use_tls: "no"
+postfix_smtp_tls_note_starttls_offer: "no"
+postfix_smtp_tls_CAfile: ""
+postfix_smtp_tls_CApath: ""
+postfix_tls_append_default_CA: "no"
+
+postfix_smtp_sender_dependent_authentication: "no"
+postfix_sender_dependent_relayhost_map: ""
+postfix_sender_dependent_relayhost_map_content: ""
+
+postfix_sender_canonical_classes: "envelope_sender, header_sender"
+postfix_sender_canonical_map: ""
+postfix_sender_canonical_map_content: ""
+
+# Debugging options
+postfix_debug_peer_level: 2
+# postfix_debug_peer_list: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,6 +16,26 @@
     cmd: postmap "{{ postfix_recipient_access_path }}"
   changed_when: true
 
+- name: Rebuild client_access database
+  ansible.builtin.command:
+    cmd: postmap "{{ postfix_client_access_path }}"
+  changed_when: true
+
+- name: Rebuild relay_access database
+  ansible.builtin.command:
+    cmd: postmap "{{ postfix_relay_access_path }}"
+  changed_when: true
+
+- name: Rebuild sender_dependent_relayhost_map database
+  ansible.builtin.command:
+    cmd: postmap "{{ postfix_sender_dependent_relayhost_map }}"
+  changed_when: true
+
+- name: Rebuild sender_canonical_map database
+  ansible.builtin.command:
+    cmd: postmap "{{ postfix_sender_canonical_map }}"
+  changed_when: true
+
 - name: Rebuild transport_maps database
   ansible.builtin.command:
     cmd: postmap /etc/postfix/transport
@@ -35,8 +55,10 @@
   ansible.builtin.service:
     name: "{{ postfix_service }}"
     state: reloaded
+  when: not ansible_check_mode
 
 - name: Restart postfix
   ansible.builtin.service:
     name: "{{ postfix_service }}"
     state: restarted
+  when: not ansible_check_mode

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -80,6 +80,24 @@
   when:
     - postfix_tls_protocols is defined
 
+- name: assert | Test postfix_smtpd_client_restrictions
+  ansible.builtin.assert:
+    that:
+      - postfix_smtpd_client_restrictions is defined
+      - postfix_smtpd_client_restrictions is iterable
+    quiet: true
+  when:
+    - postfix_smtpd_client_restrictions is defined
+
+- name: assert | Test postfix_smtpd_relay_restrictions
+  ansible.builtin.assert:
+    that:
+      - postfix_smtpd_relay_restrictions is defined
+      - postfix_smtpd_relay_restrictions is iterable
+    quiet: true
+  when:
+    - postfix_smtpd_relay_restrictions is defined
+
 - name: assert | Test postfix_smtp_tls_security_level
   ansible.builtin.assert:
     that:
@@ -488,3 +506,18 @@
     quiet: true
   when:
     - postfix_master_custom is defined
+
+- name: Check postfix_debug_peer_level
+  assert:
+    that:
+      - postfix_debug_peer_level is defined
+      - postfix_debug_peer_level | int is not none
+    quiet: true
+  when: postfix_debug_peer_level is defined
+
+- name: Check postfix_debug_peer_list (optional)
+  assert:
+    that:
+      - postfix_debug_peer_list is iterable
+    quiet: true
+  when: postfix_debug_peer_list is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,14 @@
       {% if postfix_sender_access is defined %}
       check_sender_access hash:{{ postfix_sender_access_path }},
       {% endif %}
+    _postfix_smtpd_client_restrictions_check_client_access: |
+      {% if postfix_client_access is defined %}
+      check_client_access hash:{{ postfix_client_access_path }},
+      {% endif %}
+    _postfix_smtpd_relay_restrictions_check_relay_access: |
+      {% if postfix_relay_access is defined %}
+      check_client_access hash:{{ postfix_relay_access_path }},
+      {% endif %}
 
 - name: "Setting values for main.cf (2/2)"
   ansible.builtin.set_fact:
@@ -104,6 +112,22 @@
       {{ _postfix_smtpd_sender_restrictions_check_sender_access | trim }} {{ postfix_smtpd_sender_restrictions }}
       {% elif postfix_smtpd_sender_restrictions is iterable and (postfix_smtpd_sender_restrictions is not string and postfix_smtpd_sender_restrictions is not mapping) %}
       {{ _postfix_smtpd_sender_restrictions_check_sender_access | trim }} {% for domain in postfix_smtpd_sender_restrictions %}{{ domain }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% endif %}
+    _postfix_smtpd_client_restrictions: >-
+      {% if postfix_smtpd_client_restrictions is defined %}
+      {% if postfix_smtpd_client_restrictions is string %}
+      {{ _postfix_smtpd_client_restrictions_check_client_access | trim }} {{ postfix_smtpd_client_restrictions }}
+      {% elif postfix_smtpd_client_restrictions is iterable and (postfix_smtpd_client_restrictions is not string and postfix_smtpd_client_restrictions is not mapping) %}
+      {{ _postfix_smtpd_client_restrictions_check_client_access | trim }} {% for client in postfix_smtpd_client_restrictions %}{{ client }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+      {% endif %}
+    _postfix_smtpd_relay_restrictions: >-
+      {% if postfix_smtpd_relay_restrictions is defined %}
+      {% if postfix_smtpd_relay_restrictions is string %}
+      {{ _postfix_smtpd_relay_restrictions_check_relay_access | trim }} {{ postfix_smtpd_relay_restrictions }}
+      {% elif postfix_smtpd_relay_restrictions is iterable and (postfix_smtpd_relay_restrictions is not string and postfix_smtpd_relay_restrictions is not mapping) %}
+      {{ _postfix_smtpd_relay_restrictions_check_relay_access | trim }} {% for relay in postfix_smtpd_relay_restrictions %}{{ relay }}{% if not loop.last %}, {% endif %}{% endfor %}
       {% endif %}
       {% endif %}
     _postfix_virtual_mailbox_domains: >-
@@ -184,53 +208,117 @@
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 
-- name: Configure aliases
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_alias_path }}"
-    regexp: "^{{ item.name }}:"
-    line: "{{ item.name }}: {{ item.destination }}"
-    mode: "0644"
-  when:
-    - postfix_aliases is defined
-  loop: "{{ postfix_aliases }}"
+- name: Ensure alias database exists
+  ansible.builtin.command:
+    cmd: postalias "{{ postfix_alias_path }}"
+    creates: "{{ postfix_alias_path }}.db"
   notify:
     - Rebuild alias database
     - Reload postfix
-  loop_control:
-    label: "{{ item.name }}"
+
+- name: Configure aliases
+  ansible.builtin.copy:
+    dest: "{{ postfix_alias_path }}"
+    content: |
+      {% for alias in postfix_aliases %}
+      {{ alias.name }}: {{ alias.destination }}
+      {% endfor %}
+    mode: "0644"
+  when:
+    - postfix_aliases is defined
+    - postfix_aliases | length > 0
+  notify:
+    - Validate configuration
+    - Rebuild alias database
+    - Reload postfix
 
 - name: Configure sender_access
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_sender_access_path }}"
-    regexp: "^{{ item.domain }}"
-    line: "{{ item.domain }} {{ item.action }}"
-    create: true
+  ansible.builtin.copy:
+    dest: "{{ postfix_sender_access_path }}"
+    content: |
+      {% for entry in postfix_sender_access %}
+      {{ entry.domain }} {{ entry.action }}
+      {% endfor %}
     mode: "0644"
   when:
     - postfix_sender_access is defined
-  loop: "{{ postfix_sender_access }}"
+    - postfix_sender_access | length > 0
   notify:
+    - Validate configuration
     - Rebuild sender_access database
     - Reload postfix
-  loop_control:
-    label: "{{ item.domain }}"
 
 - name: Configure recipient_access
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_recipient_access_path }}"
-    regexp: "^{{ item.domain }}"
-    line: "{{ item.domain }} {{ item.action }}"
-    create: true
+  ansible.builtin.copy:
+    dest: "{{ postfix_recipient_access_path }}"
+    content: |
+      {% for entry in postfix_recipient_access %}
+      {{ entry.domain }} {{ entry.action }}
+      {% endfor %}
     mode: "0644"
   when:
     - postfix_recipient_access is defined
-  loop: "{{ postfix_recipient_access }}"
+    - postfix_recipient_access | length > 0
   notify:
     - Validate configuration
     - Rebuild recipient_access database
     - Reload postfix
-  loop_control:
-    label: "{{ item.domain }}"
+
+- name: Configure client_access
+  ansible.builtin.copy:
+    dest: "{{ postfix_client_access_path }}"
+    content: |
+      {% for entry in postfix_client_access %}
+      {{ entry.client }} {{ entry.action }}
+      {% endfor %}
+    mode: "0644"
+  when:
+    - postfix_client_access is defined
+    - postfix_client_access | length > 0
+  notify:
+    - Validate configuration
+    - Rebuild client_access database
+    - Reload postfix
+
+- name: Configure relay_access
+  ansible.builtin.copy:
+    dest: "{{ postfix_relay_access_path }}"
+    content: |
+      {% for entry in postfix_relay_access %}
+      {{ entry.client }} {{ entry.action }}
+      {% endfor %}
+    mode: "0644"
+  when:
+    - postfix_relay_access is defined
+    - postfix_relay_access | length > 0
+  notify:
+    - Validate configuration
+    - Rebuild relay_access database
+    - Reload postfix
+
+- name: Place sender_dependent_relayhost_map
+  ansible.builtin.copy:
+    content: "{{ postfix_sender_dependent_relayhost_map_content }}"
+    dest: "{{ postfix_sender_dependent_relayhost_map }}"
+    mode: "0600"
+  when:
+    - postfix_sender_dependent_relayhost_map is defined and postfix_sender_dependent_relayhost_map != ""
+  notify:
+    - Validate configuration
+    - Rebuild sender_dependent_relayhost_map database
+    - Reload postfix
+
+- name: Place sender_canonical_map
+  ansible.builtin.copy:
+    content: "{{ postfix_sender_canonical_map_content }}"
+    dest: "{{ postfix_sender_canonical_map }}"
+    mode: "0600"
+  when:
+    - postfix_sender_canonical_map is defined and postfix_sender_canonical_map != ""
+  notify:
+    - Validate configuration
+    - Rebuild sender_canonical_map database
+    - Reload postfix
 
 - name: Place sasl_password_map
   ansible.builtin.copy:
@@ -240,7 +328,9 @@
   when:
     - postfix_smtp_sasl_password_map is defined and postfix_smtp_sasl_password_map != ""
   notify:
+    - Validate configuration
     - Rebuild sasl_password_map database
+    - Reload postfix
 
 - name: Flush handlers again
   ansible.builtin.meta: flush_handlers
@@ -250,3 +340,4 @@
     name: "{{ postfix_service }}"
     state: started
     enabled: true
+  when: not ansible_check_mode

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -330,6 +330,11 @@ smtpd_recipient_restrictions = {{ _postfix_smtpd_recipient_restrictions | trim }
 
 smtpd_sender_restrictions = {{ _postfix_smtpd_sender_restrictions | trim }}
 
+smtpd_client_restrictions = {{ _postfix_smtpd_client_restrictions | trim }}
+
+{% if _postfix_smtpd_relay_restrictions != "" -%}
+smtpd_relay_restrictions = {{ _postfix_smtpd_relay_restrictions | trim }}
+{% endif -%}
 
 # INTERNET OR INTRANET
 
@@ -642,7 +647,7 @@ smtpd_banner = {{ postfix_banner }}
 # logging level when an SMTP client or server host name or address
 # matches a pattern in the debug_peer_list parameter.
 #
-debug_peer_level = 2
+debug_peer_level = {{ postfix_debug_peer_level }}
 
 # The debug_peer_list parameter specifies an optional list of domain
 # or network patterns, /file/name patterns or type:name tables. When
@@ -652,6 +657,9 @@ debug_peer_level = 2
 #
 #debug_peer_list = 127.0.0.1
 #debug_peer_list = some.domain
+{% if postfix_debug_peer_list is defined and postfix_debug_peer_list | length > 0 %}
+debug_peer_list = {{ postfix_debug_peer_list | join(',') }}
+{% endif %}
 
 # The debugger_command specifies the external command that is executed
 # when a Postfix daemon program is run with the -D option.
@@ -747,6 +755,16 @@ smtp_tls_protocols = {{ postfix_tls_protocols }}
 
 # The default SMTP TLS security level for the Postfix SMTP client
 smtp_tls_security_level = {{ postfix_smtp_tls_security_level }}
+
+smtp_use_tls = {{ postfix_smtp_use_tls }}
+
+smtp_tls_note_starttls_offer = {{ postfix_smtp_tls_note_starttls_offer }}
+
+smtp_tls_CAfile = {{ postfix_smtp_tls_CAfile }}
+
+smtp_tls_CApath = {{ postfix_smtp_tls_CApath }}
+
+tls_append_default_CA = {{ postfix_tls_append_default_CA }}
 
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = hash:/etc/postfix/transport
@@ -893,6 +911,16 @@ smtpd_client_connection_count_limit = {{ postfix_smtpd_client_connection_count_l
 
 {% if postfix_bounce_queue_lifetime is defined %}
 bounce_queue_lifetime = {{ postfix_bounce_queue_lifetime }}
+{% endif %}
+
+smtp_sender_dependent_authentication = {{ postfix_smtp_sender_dependent_authentication }}
+{% if postfix_sender_dependent_relayhost_map %}
+sender_dependent_relayhost_maps = hash:{{ postfix_sender_dependent_relayhost_map }}
+{% endif %}
+
+sender_canonical_classes = {{ postfix_sender_canonical_classes }}
+{% if postfix_sender_canonical_map %}
+sender_canonical_maps = hash:{{ postfix_sender_canonical_map }}
 {% endif %}
 
 # https://stafwag.github.io/blog/blog/2018/03/04/postfix-smarthost-with-authentication/

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -189,7 +189,7 @@ inet_protocols = {{ postfix_inet_protocols }}
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain,
 #	mail.$mydomain, www.$mydomain, ftp.$mydomain
-{% if _postfix_mydestination != "<None>" %}
+{% if _postfix_mydestination != "<None>" -%}
 mydestination = {{ _postfix_mydestination | trim }}
 {% endif %}
 
@@ -322,7 +322,7 @@ mynetworks = {{ _postfix_mynetworks | trim }}
 # permit_mx_backup restriction description in postconf(5).
 #
 #relay_domains = $mydestination
-{% if _postfix_relay_domains != "<None>" %}
+{% if _postfix_relay_domains != "<None>" -%}
 relay_domains = {{ _postfix_relay_domains | trim }}
 {% endif %}
 
@@ -356,9 +356,9 @@ smtpd_relay_restrictions = {{ _postfix_smtpd_relay_restrictions | trim }}
 #relayhost = [mailserver.isp.tld]
 #relayhost = uucphost
 #relayhost = [an.ip.add.ress]
-{% if postfix_relayhost is defined and postfix_relayhost | length > 0 %}
+{% if postfix_relayhost is defined and postfix_relayhost | length > 0 -%}
 relayhost = {{ postfix_relayhost|replace("'", "") }}
-{% endif %}
+{% endif -%}
 
 # REJECTING UNKNOWN RELAY USERS
 #
@@ -427,7 +427,7 @@ relayhost = {{ postfix_relayhost|replace("'", "") }}
 # "postfix reload" to eliminate the delay.
 #
 #alias_maps = dbm:/etc/aliases
-{% if postfix_alias_maps is defined %}
+{% if postfix_alias_maps is defined -%}
 alias_maps = {{ postfix_alias_maps }}
 {% endif %}
 
@@ -593,8 +593,7 @@ alias_database = hash:{{ postfix_alias_path }}
 # For details, see "man header_checks".
 #
 #header_checks = regexp:/etc/postfix/header_checks
-
-{% if postfix_header_checks_template is defined %}
+{% if postfix_header_checks_template is defined -%}
 header_checks = regexp:/etc/postfix/header_checks
 {% endif %}
 
@@ -657,7 +656,7 @@ debug_peer_level = {{ postfix_debug_peer_level }}
 #
 #debug_peer_list = 127.0.0.1
 #debug_peer_list = some.domain
-{% if postfix_debug_peer_list is defined and postfix_debug_peer_list | length > 0 %}
+{% if postfix_debug_peer_list is defined and postfix_debug_peer_list | length > 0 -%}
 debug_peer_list = {{ postfix_debug_peer_list | join(',') }}
 {% endif %}
 
@@ -718,7 +717,7 @@ setgid_group = {{ postfix_group }}
 
 # html_directory: The location of the Postfix HTML documentation.
 #
-{% if postfix_html_directory is defined %}
+{% if postfix_html_directory is defined -%}
 html_directory = {{ postfix_html_directory }}
 {% endif %}
 
@@ -733,17 +732,17 @@ sample_directory = /usr/share/doc/postfix-2.10.1/samples
 
 # readme_directory: The location of the Postfix README files.
 #
-{% if postfix_readme_directory is defined %}
+{% if postfix_readme_directory is defined -%}
 readme_directory = {{ postfix_readme_directory }}
 {% endif %}
 
 # content_filter: An optional filter to classify content.
-{% if postfix_clamav is defined and postfix_clamav == "enabled" %}
+{% if postfix_clamav is defined and postfix_clamav == "enabled" -%}
 content_filter = scan:127.0.0.1:10025
 receive_override_options = no_address_mappings
 {% endif %}
 
-{% if postfix_tls_protocols is defined %}
+{% if postfix_tls_protocols is defined -%}
 # smtpd_tls_mandatory_protcols: TLS protocols accepted by the Postfix SMTP
 # server with mandatory TLS encryption.
 #
@@ -768,167 +767,167 @@ tls_append_default_CA = {{ postfix_tls_append_default_CA }}
 
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = hash:/etc/postfix/transport
-{% if postfix_transport_maps_template is defined %}
+{% if postfix_transport_maps_template is defined -%}
 transport_maps = hash:/etc/postfix/transport
 {% endif %}
 
-{% if postfix_biff is defined %}
+{% if postfix_biff is defined -%}
 biff = {% if postfix_biff %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_append_dot_mydomain is defined %}
+{% if postfix_append_dot_mydomain is defined -%}
 append_dot_mydomain = {% if postfix_append_dot_mydomain %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_virtual_mailbox_base is defined %}
+{% if postfix_virtual_mailbox_base is defined -%}
 virtual_mailbox_base = {{ postfix_virtual_mailbox_base }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_virtual_mailbox_maps is defined %}
+{% if postfix_virtual_mailbox_maps is defined -%}
 virtual_mailbox_maps = {{ postfix_virtual_mailbox_maps }}
-{% endif %}
+{% endif -%}
 
 {% if _postfix_virtual_mailbox_domains | trim != "<None>" %}
 virtual_alias_domains = {{ _postfix_virtual_mailbox_domains | trim }}
-{% endif %}
+{% endif -%}
 
 {% if _postfix_virtual_alias_domains | trim != "<None>" %}
 virtual_mailbox_domains = {{ _postfix_virtual_alias_domains | trim }}
-{% endif %}
+{% endif -%}
 
-{% if postix_virtual_alias_maps is defined %}
+{% if postix_virtual_alias_maps is defined -%}
 virtual_alias_maps = {{ postix_virtual_alias_maps }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_virtual_uid_maps is defined %}
+{% if postfix_virtual_uid_maps is defined -%}
 virtual_uid_maps = {{ postfix_virtual_uid_maps }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_virtual_gid_maps is defined %}
+{% if postfix_virtual_gid_maps is defined -%}
 virtual_gid_maps = {{ postfix_virtual_gid_maps }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_sasl_auth_enable is defined %}
+{% if postfix_smtpd_sasl_auth_enable is defined -%}
 smtpd_sasl_auth_enable = {% if postfix_smtpd_sasl_auth_enable %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_sasl_local_domain is defined %}
+{% if postfix_smtpd_sasl_local_domain is defined -%}
 smtpd_sasl_local_domain = {{ postfix_smtpd_sasl_local_domain }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_sasl_security_options is defined %}
+{% if postfix_smtpd_sasl_security_options is defined -%}
 smtpd_sasl_security_options = {{ postfix_smtpd_sasl_security_options }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_sasl_authenticated_header is defined %}
+{% if postfix_smtpd_sasl_authenticated_header is defined -%}
 smtpd_sasl_authenticated_header = {% if postfix_smtpd_sasl_authenticated_header %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_broken_sasl_auth_clients is defined %}
+{% if postfix_broken_sasl_auth_clients is defined -%}
 broken_sasl_auth_clients = {% if postfix_broken_sasl_auth_clients %}yes{% else %}no{% endif %}
 
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_cert_file is defined %}
+{% if postfix_smtpd_tls_cert_file is defined -%}
 smtpd_tls_cert_file = {{ postfix_smtpd_tls_cert_file }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_key_file is defined %}
+{% if postfix_smtpd_tls_key_file is defined -%}
 smtpd_tls_key_file = {{ postfix_smtpd_tls_key_file }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_received_header is defined %}
+{% if postfix_smtpd_tls_received_header is defined -%}
 smtpd_tls_received_header = {% if postfix_smtpd_tls_received_header %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_security_level is defined %}
+{% if postfix_smtpd_tls_security_level is defined -%}
 smtpd_tls_security_level = {{ postfix_smtpd_tls_security_level }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_ask_ccert is defined %}
+{% if postfix_smtpd_tls_ask_ccert is defined -%}
 smtpd_tls_ask_ccert = {% if postfix_smtpd_tls_ask_ccert %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_loglevel is defined %}
+{% if postfix_smtpd_tls_loglevel is defined -%}
 smtpd_tls_loglevel = {{ postfix_smtpd_tls_loglevel }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_session_cache_database is defined %}
+{% if postfix_smtpd_tls_session_cache_database is defined -%}
 smtpd_tls_session_cache_database = {{ postfix_smtpd_tls_session_cache_database }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtp_tls_cert_file is defined %}
+{% if postfix_smtp_tls_cert_file is defined -%}
 smtp_tls_cert_file = {{ postfix_smtp_tls_cert_file }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtp_tls_key_file is defined %}
+{% if postfix_smtp_tls_key_file is defined -%}
 smtp_tls_key_file = {{ postfix_smtp_tls_key_file }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtp_tls_session_cache_database is defined %}
+{% if postfix_smtp_tls_session_cache_database is defined -%}
 smtp_tls_session_cache_database = {{ postfix_smtp_tls_session_cache_database }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_tls_random_source is defined %}
+{% if postfix_tls_random_source is defined -%}
 tls_random_source = {{ postfix_tls_random_source }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_tls_mandatory_protocols is defined %}
+{% if postfix_smtpd_tls_mandatory_protocols is defined -%}
 smtpd_tls_mandatory_protocols = {{ postfix_smtpd_tls_mandatory_protocols }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtp_tls_mandatory_protocols is defined %}
+{% if postfix_smtp_tls_mandatory_protocols is defined -%}
 smtp_tls_mandatory_protocols = {{ postfix_smtp_tls_mandatory_protocols }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_virtual_transport is defined %}
+{% if postfix_virtual_transport is defined -%}
 virtual_transport = {{ postfix_virtual_transport }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_home_mailbox is defined %}
+{% if postfix_home_mailbox is defined -%}
 home_mailbox = {{ postfix_home_mailbox }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_message_size_limit is defined %}
+{% if postfix_message_size_limit is defined -%}
 message_size_limit = {{ postfix_message_size_limit }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_helo_required is defined %}
+{% if postfix_smtpd_helo_required is defined -%}
 smtpd_helo_required = {% if postfix_smtpd_helo_required %}yes{% else %}no{% endif %}
-{% endif %}
+{% endif -%}
 
-{% if postfix_anvil_rate_time_unit is defined %}
+{% if postfix_anvil_rate_time_unit is defined -%}
 anvil_rate_time_unit = {{ postfix_anvil_rate_time_unit }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_client_connection_rate_limit is defined %}
+{% if postfix_smtpd_client_connection_rate_limit is defined -%}
 smtpd_client_connection_rate_limit = {{ postfix_smtpd_client_connection_rate_limit }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_smtpd_client_connection_count_limit is defined %}
+{% if postfix_smtpd_client_connection_count_limit is defined -%}
 smtpd_client_connection_count_limit = {{ postfix_smtpd_client_connection_count_limit }}
-{% endif %}
+{% endif -%}
 
-{% if postfix_bounce_queue_lifetime is defined %}
+{% if postfix_bounce_queue_lifetime is defined -%}
 bounce_queue_lifetime = {{ postfix_bounce_queue_lifetime }}
-{% endif %}
+{% endif -%}
 
 smtp_sender_dependent_authentication = {{ postfix_smtp_sender_dependent_authentication }}
-{% if postfix_sender_dependent_relayhost_map %}
+{% if postfix_sender_dependent_relayhost_map -%}
 sender_dependent_relayhost_maps = hash:{{ postfix_sender_dependent_relayhost_map }}
-{% endif %}
+{% endif -%}
 
 sender_canonical_classes = {{ postfix_sender_canonical_classes }}
-{% if postfix_sender_canonical_map %}
+{% if postfix_sender_canonical_map -%}
 sender_canonical_maps = hash:{{ postfix_sender_canonical_map }}
-{% endif %}
+{% endif -%}
 
 # https://stafwag.github.io/blog/blog/2018/03/04/postfix-smarthost-with-authentication/
 smtp_sasl_auth_enable = {{ postfix_smtp_sasl_auth_enable | ternary('yes', 'no') }}
-{% if postfix_smtp_sasl_password_map is defined and postfix_smtp_sasl_password_map != "" %}
+{% if postfix_smtp_sasl_password_map is defined and postfix_smtp_sasl_password_map != "" -%}
 smtp_sasl_password_maps = hash:{{ postfix_smtp_sasl_password_map }}
-{% endif %}
-{% if postfix_smtp_sasl_security_options is defined and postfix_smtp_sasl_security_options != "" %}
+{% endif -%}
+{% if postfix_smtp_sasl_security_options is defined and postfix_smtp_sasl_security_options != "" -%}
 smtp_sasl_security_options = {{ postfix_smtp_sasl_security_options }}
-{% endif %}
+{% endif -%}
 smtp_tls_wrappermode = {{ postfix_smtp_tls_wrappermode | ternary('yes', 'no') }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,6 +20,10 @@ postfix_recipient_access_path: /etc/postfix/recipient_access
 
 postfix_sender_access_path: /etc/postfix/sender_access
 
+postfix_client_access_path: /etc/postfix/client_access
+
+postfix_relay_access_path: /etc/postfix/relay_access
+
 _postfix_group:
   default: postdrop
   Suse: maildrop


### PR DESCRIPTION
---
name: More options
about: Added many options

---

**Describe the change**

#### Added following options:
- smtpd_client_restrictions
- smtpd_relay_restrictions
- smtp_use_tls
- smtp_tls_note_starttls_offer
- smtp_tls_CAfile
- smtp_tls_CApath
- tls_append_default_CA
- smtp_sender_dependent_authentication
- sender_dependent_relayhost_maps
- sender_canonical_classes
- sender_canonical_maps
- debug_peer_level
- debug_peer_list

#### Improvements:
- make check mode work
- make sure alias database exist to avoid error on fresh Ubuntu
- switch from lineinfile to copy because changed entries were not changed but added
- reduced number of empty lines in final main.cf

**Testing**
Tested in new production environment