### PR TITLE
Add a custom transport_maps variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ postfix_smtp_tls_security_level: none
 # You can supply a transport_maps Jinja2 template here
 # postfix_transport_maps_template: /path/to/transport.j2
 
+# You can supply a custom transport_maps value here (takes precedence over postfix_transport_maps_template)
+# postfix_transport_maps_custom: "lmdb:/etc/postfix/transport, lmdb:/etc/postfix/transport_sec"
+
 # You can supply a header_checks Jinja2 template here
 # postfix_header_checks_template: /path/to/header_checks.j2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,6 +113,9 @@ postfix_smtp_tls_security_level: none
 # You can supply a transport_maps Jinja2 template here
 # postfix_transport_maps_template: /path/to/transport.j2
 
+# You can supply a custom transport_maps value here (takes precedence over postfix_transport_maps_template)
+# postfix_transport_maps_custom: "lmdb:/etc/postfix/transport, lmdb:/etc/postfix/transport_sec"
+
 # You can supply a header_checks Jinja2 template here
 # postfix_header_checks_template: /path/to/header_checks.j2
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -142,6 +142,11 @@ argument_specs:
         required: false
         description: Path to a transport_maps Jinja2 template.
 
+      postfix_transport_maps_custom:
+        type: str
+        required: false
+        description: Custom transport_maps value (takes precedence over postfix_transport_maps_template).
+
       postfix_header_checks_template:
         type: str
         required: false
@@ -404,6 +409,26 @@ argument_specs:
         elements: dict
         required: false
         description: List of custom master.cf entries if more services are needed outside of postfix defaults.
+
+      postfix_smtpd_milters:
+        type: raw
+        required: false
+        description: Yaml list (or string of comma-separated list) of Postfix before-queue SMTP-only milters.
+
+      postfix_non_smtpd_milters:
+        type: raw
+        required: false
+        description: Yaml list (or string of comma-separated list) of Postfix before-queue non-SMTP milters.
+
+      postfix_milter_default_action:
+        type: str
+        required: false
+        choices:
+          - accept
+          - reject
+          - tempfail
+          - quarantine
+        description: What to do in case of errors from milters. Specify accept, reject, tempfail, or quarantine (Postfix 2.6 or later).
 
       postfix_smtp_listen_port:
         type: raw

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -789,7 +789,9 @@ tls_append_default_CA = {{ postfix_tls_append_default_ca }}
 
 # Optional lookup tables with mappings from recipient address to (message delivery transport, next-hop destination).
 # transport_maps = lmdb:/etc/postfix/transport
-{% if postfix_transport_maps_template is defined %}
+{% if postfix_transport_maps_custom is defined %}
+transport_maps = {{ postfix_transport_maps_custom }}
+{% elif postfix_transport_maps_template is defined %}
 transport_maps = lmdb:/etc/postfix/transport
 {% endif %}
 


### PR DESCRIPTION
This PR introduces a variable to set a custom transport_maps value, useful for configuring other services that use Postfix as their MTA, for example [Sympa](https://www.sympa.community/).

I also added the milter options to `argument_specs.yml`. I had to use the `raw` type (no validation) because of the two types allowed (yaml list or comma-separated list).